### PR TITLE
Correct compilation reference name

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ Plugin.prototype.apply = function(compiler) {
       compiler.hooks.compile.tap(plugin, compile);
       compiler.hooks.done.tap(plugin, done);
     } else {
-      compiler.plugin('compilation', compilation);
+      compiler.plugin('compilation', _compilation);
       compiler.plugin('compile', compile);
       compiler.plugin('done', done);
     }


### PR DESCRIPTION
@owais, the recent release has an invalid reference to the compilation variable and is causing our webpack builds to fail.    

I've tested this change locally.   Thanks again for the quick turnaround on this!  